### PR TITLE
chore: setup properly semantic release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,32 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-
+      #------------------------------------------------
+      #  -----  check-out repo and set-up python  -----
+      #------------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      #------------------------------
+      #  -----  Setup Node.js  -----
+      #------------------------------
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
-
+      #------------------------------
+      #  -----  Install poetry  -----
+      #------------------------------
+      - name: Install Poetry
+        uses: abatilo/actions-poetry@v2.0.0
+        with:
+          poetry-version: 1.1.11
+      #---------------------------------------
+      #  -----  Install Semantic Release -----
+      #---------------------------------------
       - name: Install Semantic Release
         run: |
           npm install -g semantic-release           \
@@ -30,7 +50,9 @@ jobs:
           @semantic-release/exec                    \
           @semantic-release/github                  \
           @semantic-release/release-notes-generator
-
+      #-----------------------------------
+      #  -----  Run Semantic Release -----
+      #-----------------------------------
       - name: Run Semantic Release
         env:
            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,15 @@
+branches:
+  - main
+  - next
+preset: angular
+plugins:
+  - path: "@semantic-release/commit-analyzer"
+  - path: "@semantic-release/exec"
+    publishCmd: "sh release_package.sh ${nextRelease.version}"
+  - path: "@semantic-release/changelog"
+    changelogFile: "CHANGELOG.md"
+  - path: "@semantic-release/release-notes-generator"
+  - path: "@semantic-release/github"
+    assets:
+      - path: "dist/sample_package-0.1.0-py3-none-any.whl"
+        label: "Python Package"


### PR DESCRIPTION
Semantic release needs a `.releaserc` file. I also fixed the release workflow to be able to run poetry.